### PR TITLE
Update split() to return list of lists

### DIFF
--- a/semantic_split/splitters/SimilarSentenceSplitter.py
+++ b/semantic_split/splitters/SimilarSentenceSplitter.py
@@ -11,7 +11,7 @@ class SimilarSentenceSplitter(Splitter):
         self.model = similarity_model
         self.sentence_splitter = sentence_splitter
 
-    def split(self, text: str, group_max_sentences=5) -> List[str]:
+    def split(self, text: str, group_max_sentences=5) -> List[List[str]]:
         '''
             group_max_sentences: The maximum number of sentences in a group.
         '''


### PR DESCRIPTION
Thanks for your library!

I noticed a small mistake. Your type annotation for `SimilarSentenceSplitter().split()` is `List[str]` but in fact the method returns `List[List[str]]`, as in your README example.

If I have misunderstood something and my fix is not correct, please do not worry about being polite, you can just close it :D

<img width="875" alt="image" src="https://github.com/agamm/semantic-split/assets/1854968/4473b130-b230-4580-9b22-5e5e4a1da2dc">
